### PR TITLE
chore(docker): solved npm bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,11 @@ FROM node:lts-alpine
 
 WORKDIR /appointment-svc
 
-COPY . .
+COPY package.json package-lock.json ./
 
 RUN npm ci --omit=dev && \
-rm -rf $(npm get cache)
+    rm -rf $(npm get cache)
+
+COPY . .
 
 ENTRYPOINT ["npm", "start"]
-# ENTRYPOINT ["npm", "run", "dev"]


### PR DESCRIPTION
This pull request includes changes to the `Dockerfile` to optimize the build process for the `appointment-svc` service. The most important changes include modifying the order of file copying and removing an unused entry point.

Dockerfile optimization:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L5-L11): Changed the order of copying files to first copy `package.json` and `package-lock.json` before running `npm ci`, and then copying the rest of the files. This reduces the number of layers and leverages Docker's caching mechanism more effectively.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L5-L11): Removed the commented-out `ENTRYPOINT` line that was previously set to run the development server.