### PR TITLE
fix(kubernetes): renamed dragonfly svc

### DIFF
--- a/kubernetes/dragonfly-service.yaml
+++ b/kubernetes/dragonfly-service.yaml
@@ -6,7 +6,7 @@ metadata:
     kompose.version: 1.34.0 (HEAD)
   labels:
     io.kompose.service: dragonfly-appointment
-  name: dragonfly
+  name: dragonfly-appointment
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
This pull request includes a small but important change to the `kubernetes/dragonfly-service.yaml` file. The change updates the `metadata` section to correct the service name.

* [`kubernetes/dragonfly-service.yaml`](diffhunk://#diff-bc7bd13865ee42f4eacf494c2d1120210b35ba30828a704223986b94f6b4472eL9-R9): Changed the `name` field in the `metadata` section from `dragonfly` to `dragonfly-appointment` to ensure consistency with the service label.